### PR TITLE
Update env file so that we can get the webhook request to the host machine

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-WEBHOOK_URL=http://localhost:3010/webhooks
+WEBHOOK_URL=http://host.docker.internal:3010/webhooks
 WEBHOOK_SECRET=mySecret


### PR DESCRIPTION
The configuration on the env file in changes to make sure that instead of trying to hit the localhost of the docker container where the server is running, we instead send the webhook request to the server running on the host.